### PR TITLE
fix: report error for non 2xx status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Improved reporting for bad HTTP status codes. (#90)
+
 ## 1.0.1
 
 - fix: `raw_url` is optional, check for the existance of it only for the changelog change. (#12)

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -92,7 +92,7 @@ pub fn check(repo_name: &str, pr_number: &str, changelog_path: &str) -> Result<V
         format!("https://api.github.com/repos/{repo_name}/pulls/{pr_number}/files").as_str(),
     )?;
 
-    let resp: GitHubPrFiles = client.get(url).send()?.json()?;
+    let resp: GitHubPrFiles = client.get(url).send()?.error_for_status()?.json()?;
     let mut added_entries: Vec<AddedEntry> = Vec::new();
 
     let changelog_diff_entry = resp.into_iter().find(|c| c.filename == changelog_path);


### PR DESCRIPTION
Previously, these responses would be parsed as JSON and emitted an error while deserializing.